### PR TITLE
Feature/multiple relationship

### DIFF
--- a/inc/query/class-mb-relationships-query-normalizer.php
+++ b/inc/query/class-mb-relationships-query-normalizer.php
@@ -32,16 +32,28 @@ class MB_Relationships_Query_Normalizer {
 	 * @param array $args Query arguments.
 	 */
 	public function normalize( &$args ) {
-		$direction        = isset( $args['from'] ) ? 'from' : 'to';
-		$relationship     = $this->factory->get( $args['id'] );
-		$args['id_field'] = $relationship->get_db_field( $direction );
+		// Multiple relationship type args
+		if ( isset( $args['relation'] ) ) {
+			$new_args = array(
+				'relation' => $args['relation']
+			);
+			foreach ( $args as $key => $value ) {
+				if ( 'relation' === $key ) {
+					continue;
+				}
+				
+				$value = $this->normalize_args( $value );
 
-		$args['direction'] = $direction;
-		$items             = $args[ $direction ];
-		$items             = $this->get_ids( $items, $args['id_field'] );
-		$args['items']     = $items;
+				array_push( $new_args, $value );
 
-		unset( $args[ $direction ] );
+			}
+
+			$args = $new_args;
+			return;
+		}
+
+		// Single relationship type args
+		$args = $this->normalize_args( $args );
 	}
 
 	/**
@@ -56,5 +68,25 @@ class MB_Relationships_Query_Normalizer {
 		$items = (array) $items;
 		$first = reset( $items );
 		return is_numeric( $first ) ? $items : wp_list_pluck( $items, $id_field );
+	}
+
+	/**
+	 * Normalizes relationship query argument array
+	 *
+	 * @param array $args Query arguments	
+	 */
+	protected function normalize_args( $args ) {
+		$direction        = isset( $args['from'] ) ? 'from' : 'to';
+		$relationship     = $this->factory->get( $args['id'] );
+		$args['id_field'] = $relationship->get_db_field( $direction );
+
+		$args['direction'] = $direction;
+		$items             = $args[ $direction ];
+		$items             = $this->get_ids( $items, $args['id_field'] );
+		$args['items']     = $items;
+
+		unset( $args[ $direction ] );
+
+		return $args;
 	}
 }


### PR DESCRIPTION
It's imperative to my app to query on multiple relationships in a single query. Given a Post I need to get any and all related posts to it across relationship types and to/from.

I have written this small enhancement to your code to build a dynamic `JOIN`. I based the input syntax on the WordPress `term_query`:
```
$relationship = [
    'relation' => 'OR', // the magical key to switch from single (existing) to multiple querying
    [
        'id' => 'tutorial_sequence',
        'from' => $source->ID,
    ],
    [
        'id' => 'tutorial_sequence',
        'to' => $source->ID,
    ],
    [
        'id' => 'tutorial_prereq',
        'to' => $source->ID,
    ],
];

$query_args['relationship'] = $relationship;
```

This will produce an SQL query similar to:
```
SELECT p.ID, p.post_title, mbr.* FROM `wpps_posts` p
	INNER JOIN wpps_mb_relationships mbr ON 
        (mbr.to = p.ID AND mbr.type = 'tutorial_sequence' AND mbr.from = 3892) 
        OR 
        (mbr.from = p.ID AND mbr.type = 'tutorial_sequence' AND mbr.to = 3892)
        OR
        (mbr.from = p.ID AND mbr.type = 'tutorial_prereq' AND mbr.to = 3892)
WHERE p.post_type = 'tutorial'
```
This will only work with a single input id (`from`/`to`), so the documentation would need to be explicit.

I am fairly new to PHP and WordPress development so please offer any constructive criticism regarding how I have gone about doing this.