### PR TITLE
Add flag for reciprocal relationships

### DIFF
--- a/inc/relationship/factory.php
+++ b/inc/relationship/factory.php
@@ -130,6 +130,7 @@ class MBR_Relationship_Factory {
 		$default = array(
 			'object_type' => 'post',
 			'post_type'   => 'post',
+			'reciprocal'  => false,
 			'query_args'  => array(),
 			'meta_box'    => array(
 				'hidden'        => false,


### PR DESCRIPTION
Start of a PR which allows you to have a reciprocal relationship between objects of the same post type while only creating a single metabox on the post edit screen. 

Right now, if you connect a post type to the same post type, the plugin creates a `to` and `from` metabox. The goal of this PR is to remove one of those metaboxes and still create the proper relationship in the database.

Ahn, I know this is a very small addition, but I need your direction on how this should fit together. I could see the flag going here or even inside the `metabox` array. If you provide some guidance and direction, I could lay some more code down for this.  