### PR TITLE
add field setting to metaboxes

### DIFF
--- a/inc/object/post.php
+++ b/inc/object/post.php
@@ -37,11 +37,12 @@ class MBR_Post implements MBR_Object_Interface {
 	 */
 	public function get_field_settings( $args ) {
 		return array(
-			'type'       => 'post',
-			'clone'      => true,
-			'sort_clone' => true,
-			'post_type'  => $args['post_type'],
-			'query_args' => $args['query_args'],
+			'type'       	=> 'post',
+			'clone'      	=> true,
+			'sort_clone' 	=> true,
+			'relationship' 	=> true,
+			'post_type'  	=> $args['post_type'],
+			'query_args' 	=> $args['query_args'],
 		);
 	}
 

--- a/inc/object/term.php
+++ b/inc/object/term.php
@@ -33,11 +33,12 @@ class MBR_Term implements MBR_Object_Interface {
 	 */
 	public function get_field_settings( $args ) {
 		return array(
-			'type'       => 'taxonomy_advanced',
-			'clone'      => true,
-			'sort_clone' => true,
-			'taxonomy'   => $args['taxonomy'],
-			'query_args' => $args['query_args'],
+			'type'       	=> 'taxonomy_advanced',
+			'clone'      	=> true,
+			'sort_clone' 	=> true,
+			'relationship' 	=> true,
+			'taxonomy'   	=> $args['taxonomy'],
+			'query_args' 	=> $args['query_args'],
 		);
 	}
 

--- a/inc/object/user.php
+++ b/inc/object/user.php
@@ -33,10 +33,11 @@ class MBR_User implements MBR_Object_Interface {
 	 */
 	public function get_field_settings( $args ) {
 		return array(
-			'type'       => 'user',
-			'clone'      => true,
-			'sort_clone' => true,
-			'query_args' => $args['query_args'],
+			'type'       	=> 'user',
+			'clone'      	=> true,
+			'sort_clone' 	=> true,
+			'relationship' 	=> true,
+			'query_args' 	=> $args['query_args'],
 		);
 	}
 


### PR DESCRIPTION
Hi Ahn, I am building a custom API route to manage relationships via REST. I need this flag in the field settings so that I can grab all possible relationship fields on a post type using the `rwmb_get_object_fields` function. 

In my REST response, a GET request will show all rows from the database as well as all possible relationship types that a developer can make. I envision getting all public post types, then looping through each one getting all object fields, and then serving up only the ones that have relationship equal to true. I know I can do this with a string compare, as I have done in the past, but I think this is a more robust and efficient solution than using `strpos` and looking for `to` or `from`.

At first, I was thinking about changing the `type` or `field_type` fields but that would break back compatibility. If we did change those fields, it would match how you have the Group field settings. What I have submitted , I think, is the proper path.

Thanks for including it!