### PR TITLE
Relationship labels

### DIFF
--- a/inc/relationship/factory.php
+++ b/inc/relationship/factory.php
@@ -109,10 +109,12 @@ class MBR_Relationship_Factory {
 				'id'   => '',
 				'from' => '',
 				'to'   => '',
+				'label_from'   => 'Connects From', // Translation is done in normalize_side
+				'label_to'   => 'Connects To', // Translation is done in normalize_side
 			)
 		);
-		$settings['from'] = $this->normalize_side( $settings['from'], 'from' );
-		$settings['to']   = $this->normalize_side( $settings['to'], 'to' );
+		$settings['from'] = $this->normalize_side( $settings['from'], 'from', $settings['label_from'] );
+		$settings['to']   = $this->normalize_side( $settings['to'], 'to', $settings['label_to']  );
 
 		return $settings;
 	}
@@ -125,8 +127,8 @@ class MBR_Relationship_Factory {
 	 *
 	 * @return array
 	 */
-	protected function normalize_side( $settings, $direction ) {
-		$title   = 'from' === $direction ? __( 'Connects To', 'mb-relationships' ) : __( 'Connected From', 'mb-relationship' );
+	protected function normalize_side( $settings, $direction, $label ) {
+		$title   = __( $label, 'mb-relationships' );
 		$default = array(
 			'object_type' => 'post',
 			'post_type'   => 'post',

--- a/inc/relationship/factory.php
+++ b/inc/relationship/factory.php
@@ -106,15 +106,15 @@ class MBR_Relationship_Factory {
 		$settings         = wp_parse_args(
 			$settings,
 			array(
-				'id'   => '',
-				'from' => '',
-				'to'   => '',
-				'label_from'   => 'Connects From', // Translation is done in normalize_side
+				'id'         => '',
+				'from'       => '',
+				'to'         => '',
+				'label_from' => 'Connects From', // Translation is done in normalize_side
 				'label_to'   => 'Connects To', // Translation is done in normalize_side
 			)
 		);
 		$settings['from'] = $this->normalize_side( $settings['from'], 'from', $settings['label_from'] );
-		$settings['to']   = $this->normalize_side( $settings['to'], 'to', $settings['label_to']  );
+		$settings['to']   = $this->normalize_side( $settings['to'], 'to', $settings['label_to'] );
 
 		return $settings;
 	}
@@ -135,14 +135,15 @@ class MBR_Relationship_Factory {
 			'reciprocal'  => false,
 			'query_args'  => array(),
 			'meta_box'    => array(
-				'hidden'        => false,
-				'autosave'      => false,
-				'closed'        => false,
-				'context'       => 'side',
-				'priority'      => 'low',
-				'title'         => $title,
-				'field_title'   => '',
-				'empty_message' => __( 'No connections', 'mb-relationships' ),
+				'hidden'            => false,
+				'autosave'          => false,
+				'closed'            => false,
+				'context'           => 'side',
+				'priority'          => 'low',
+				'title'             => $title,
+				'field_title'       => '',
+				'field_placeholder' => '',
+				'empty_message'     => __( 'No connections', 'mb-relationships' ),
 			),
 		);
 

--- a/inc/relationship/meta-boxes.php
+++ b/inc/relationship/meta-boxes.php
@@ -100,6 +100,9 @@ class MBR_Meta_Boxes {
 		$field         = $this->to_object->get_field_settings( $this->to );
 		$field['id']   = "{$this->id}_to";
 		$field['name'] = $this->from['meta_box']['field_title'];
+		if ( '' !== $this->from['meta_box']['field_placeholder']) {
+			$field['placeholder'] = $this->from['meta_box']['field_placeholder'];
+		}
 
 		$meta_box = array(
 			'id'           => "{$this->id}_relationships_to",
@@ -121,6 +124,9 @@ class MBR_Meta_Boxes {
 		$field         = $this->from_object->get_field_settings( $this->from );
 		$field['id']   = "{$this->id}_from";
 		$field['name'] = $this->to['meta_box']['field_title'];
+		if ( '' !== $this->from['meta_box']['field_placeholder']) {
+			$field['placeholder'] = $this->from['meta_box']['field_placeholder'];
+		}
 
 		$meta_box = array(
 			'id'           => "{$this->id}_relationships_from",


### PR DESCRIPTION
This adds two features to the relationship plugin. The ability to customize the "Connects to:" labels easily from the register function and the ability to override the placeholder message.  Since the placeholder override is likely to be more rarely used, it is accessed only from a fully configured from/to array parameter.

Simple usage of labels:
```
add_action( 'mb_relationships_init', function() {
	MB_Relationships_API::register( array(
 		'id'   => 'slideshow_to_slide',
		'from' => 'my_slideshow',
		'label_from' => 'Active Slides',
 		'to'   => 'my_slide',
		'label_to'   => 'Used by these slide shows',
	) );
} );

```
Complex use of labels and placeholders:
```
add_action( 'mb_relationships_init', function() {
	MB_Relationships_API::register( array(
 		'id'   => 'slideshow_to_slide',
		'from' => array(
			'object_type' => 'post',
			'post_type'   => 'my_slideshow',
			'reciprocal'  => false,
			'query_args'  => array(),
			'meta_box'    => array(
				'hidden'            => false,
				'autosave'          => false,
				'closed'            => false,
				'context'           => 'side',
				'priority'          => 'low',
				'title'             => 'Contained Slides',
				'field_title'       => 'Leave empty for all slides',
				'field_placeholder' => 'Choose a slide',
				'empty_message'     => __( 'All slides', 'mb-relationships' ),
			),
		),
		'to' => array(
			'object_type' => 'post',
			'post_type'   => 'my_slide',
			'reciprocal'  => false,
			'query_args'  => array(),
			'meta_box'    => array(
				'hidden'            => false,
				'autosave'          => false,
				'closed'            => false,
				'context'           => 'side',
				'priority'          => 'low',
				'title'             => 'Used by these slideshows',
				'field_title'       => '',
				'field_placeholder' => 'Choose a slideshow',
				'empty_message'     => __( 'Not used', 'mb-relationships' ),
			),
		),
	) );
} );
```

