### PR TITLE
Fix query of the storage get function for reciprocal relationships

### DIFF
--- a/inc/database/storage.php
+++ b/inc/database/storage.php
@@ -31,7 +31,7 @@ class MBR_Storage {
 
 		if ( $relationship->reciprocal ) {
 			$results = $wpdb->get_results( $wpdb->prepare(
-				"SELECT `from`, `to` FROM {$wpdb->mb_relationships} WHERE `from`=%d OR `to`=%d AND `type`=%s",
+				"SELECT `from`, `to` FROM {$wpdb->mb_relationships} WHERE (`from`=%d OR `to`=%d) AND `type`=%s",
 				$object_id,
 				$object_id,
 				$type


### PR DESCRIPTION
Hi Anh, I have been testing the new reciprocal relationships feature and ran into the following issue:

In the reciprocal relationship fields, as many dropdown menus are rendered as the entries for that post ID are found in the `form` column of the `mb-relationship` table.

Therefore, this issue is not detectable if you have only one relationship field active.

I think the update I made fixes it and it would be great if you merge it in the stable version.

Thank you!

