### PR TITLE
Add the order by clause in the query join for reciprocal relationships

### DIFF
--- a/inc/database/storage.php
+++ b/inc/database/storage.php
@@ -92,10 +92,10 @@ class MBR_Storage {
 		$target     = $this->get_target( $meta_key );
 		$source     = $this->get_source( $meta_key );
 		$type       = $this->get_type( $meta_key );
+		$orders     = $this->get_target_orders( $object_id, $type, $source, $target );
 
 		$this->delete( $object_id, $meta_key );
 
-		$orders = $this->get_target_orders( $object_id, $type, $source, $target );
 		$x = 0;
 		foreach ( $meta_value as $id ) {
 			$x++;
@@ -189,7 +189,10 @@ class MBR_Storage {
 		global $wpdb;
 
 		$items = $wpdb->get_results( $wpdb->prepare(
-			"SELECT `$target` AS `id`, `order_$target` AS `order` FROM {$wpdb->mb_relationships} WHERE `$source` = %d AND `type` = %s",
+			"SELECT `$target` AS `id`, `order_$target` AS `order` FROM {$wpdb->mb_relationships} WHERE `$source` = %d AND `type` = %s
+			UNION SELECT `$source` AS `id`, `order_$source` AS `order` FROM {$wpdb->mb_relationships} WHERE `$target` = %d AND `type` = %s",
+			$object_id,
+			$type,
 			$object_id,
 			$type
 		), ARRAY_A );

--- a/inc/database/storage.php
+++ b/inc/database/storage.php
@@ -31,13 +31,21 @@ class MBR_Storage {
 
 		if ( $relationship->reciprocal ) {
 			$results = $wpdb->get_results( $wpdb->prepare(
-				"SELECT `from`, `to` FROM {$wpdb->mb_relationships} WHERE (`from`=%d OR `to`=%d) AND `type`=%s",
+				"SELECT `to`, `order_from` AS `order`
+				FROM {$wpdb->mb_relationships}
+				WHERE `from`=%d AND `type`=%s 
+				UNION
+				SELECT `from`, `order_to` AS `order`
+				FROM {$wpdb->mb_relationships}
+				WHERE `to`=%d AND `type`=%s
+				ORDER BY `order`",
 				$object_id,
+				$type,
 				$object_id,
 				$type
 			), ARRAY_N );
-			return array_map( function( $pair ) use ( $object_id ) {
-				$pair = array_diff( $pair, [$object_id] );
+
+			return array_map( function( $pair ) {
 				return reset( $pair );
 			}, $results );
 		}

--- a/inc/database/storage.php
+++ b/inc/database/storage.php
@@ -31,14 +31,14 @@ class MBR_Storage {
 
 		if ( $relationship->reciprocal ) {
 			$results = $wpdb->get_results( $wpdb->prepare(
-				"SELECT `to`, `order_from` AS `order`
+				"SELECT `to`, `ID`, `order_from` AS `order`
 				FROM {$wpdb->mb_relationships}
 				WHERE `from`=%d AND `type`=%s 
 				UNION
-				SELECT `from`, `order_to` AS `order`
+				SELECT `from`, `ID`, `order_to` AS `order`
 				FROM {$wpdb->mb_relationships}
 				WHERE `to`=%d AND `type`=%s
-				ORDER BY `order`",
+				ORDER BY `order` ASC, `ID` DESC",
 				$object_id,
 				$type,
 				$object_id,

--- a/inc/query/query.php
+++ b/inc/query/query.php
@@ -75,9 +75,9 @@ class MBR_Query {
 		$items  = implode( ',', array_map( 'absint', $relationship['items'] ) );
 
 		if ( $relationship['reciprocal'] ) {
-			$fields             = 'mbr.from AS mbr_from, mbr.to AS mbr_to, CASE WHEN mbr.to = wp_posts.ID THEN mbr.order_from WHEN mbr.from = wp_posts.ID THEN mbr.order_to END AS `mbr_order`';
+			$fields             = 'mbr.from AS mbr_from, mbr.to AS mbr_to, mbr.ID AS mbr_id, CASE WHEN mbr.to = wp_posts.ID THEN mbr.order_from WHEN mbr.from = wp_posts.ID THEN mbr.order_to END AS `mbr_order`';
 			$clauses['fields'] .= empty( $clauses['fields'] ) ? $fields : " , $fields";
-			$clauses['orderby'] = '`mbr_order`';
+			$clauses['orderby'] = '`mbr_order` ASC, mbr_id DESC';
 			if ( empty( $clauses['groupby'] ) ) {
 				$clauses['groupby'] = 'mbr_from, mbr_to';
 			}
@@ -87,7 +87,7 @@ class MBR_Query {
 				$relationship['id'],
 				$items,
 				$items
-			);
+			);	
 		}
 
 		if ( ! $pass_thru_order ) {

--- a/inc/query/query.php
+++ b/inc/query/query.php
@@ -75,8 +75,9 @@ class MBR_Query {
 		$items  = implode( ',', array_map( 'absint', $relationship['items'] ) );
 
 		if ( $relationship['reciprocal'] ) {
-			$fields             = 'mbr.from AS mbr_from, mbr.to AS mbr_to';
+			$fields             = 'mbr.from AS mbr_from, mbr.to AS mbr_to, CASE WHEN mbr.to = wp_posts.ID THEN mbr.order_from WHEN mbr.from = wp_posts.ID THEN mbr.order_to END AS `mbr_order`';
 			$clauses['fields'] .= empty( $clauses['fields'] ) ? $fields : " , $fields";
+			$clauses['orderby'] = '`mbr_order`';
 			if ( empty( $clauses['groupby'] ) ) {
 				$clauses['groupby'] = 'mbr_from, mbr_to';
 			}


### PR DESCRIPTION
Hi Anh,

I add this pull request in reference to the issue #35

You can probably suggest some improvement in this code, but in principle fix the order in the admin. I still do not realize how to solve it for the fontend in the joins [here](https://github.com/wpmetabox/mb-relationships/blob/master/inc/query/query.php#L77).

Thanks