### PR TITLE
add FacetWP integration

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -50,18 +50,42 @@ class MB_Relationships_API {
 		return self::$factory->build( $settings );
 	}
 
+	/**
+	 * Get a single registered relationship.
+	 *
+	 * @param string $id Relationship key.
+	 *
+	 * @return MBR_Relationship|null
+	 */
 	public static function get_relationship( $id ) {
 		return self::$factory->get( $id );
 	}
 
+	/**
+	 * Get settings for the specified relationship.
+	 *
+	 * @param string $id Relationship key.
+	 *
+	 * @return array<string, string|bool|array>
+	 */
 	public static function get_relationship_settings( $id ) {
 		return self::$factory->get_settings( $id );
 	}
 
+	/**
+	 * Get all registered relationships.
+	 *
+	 * @return MBR_Relationship[]
+	 */
 	public static function get_all_relationships() {
 		return self::$factory->all();
 	}
 
+	/**
+	 * Get settings for all registered relationships.
+	 *
+	 * @return array<string, array<string|bool|array>>
+	 */
 	public static function get_all_relationships_settings() {
 		return self::$factory->all_settings();
 	}

--- a/inc/facetwp.php
+++ b/inc/facetwp.php
@@ -7,13 +7,25 @@ class MB_Relationships_FacetWP extends FacetWP_Facet {
 	const FACET_TYPE = 'mb_relationships';
 
 	/**
+	 * FacetWP Indexer.
+	 *
+	 * @var FacetWP_Indexer
+	 */
+	protected $indexer;
+
+	/**
 	 * Construct the class.
 	 *
 	 * @since 1.12.0
 	 */
 	public function __construct() {
 		$this->label = __( 'MB Relationships', 'mb-relationships' );
+
+		// Add all registered relationships as FacetWP sources.
 		add_filter( 'facetwp_facet_sources', [ $this, 'facet_sources' ] );
+
+		// Hook into indexer.
+		add_filter( 'facetwp_indexer_post_facet', [ $this, 'facetwp_indexer_post_facet' ], 10, 2 );
 	}
 
 	/**
@@ -43,5 +55,84 @@ class MB_Relationships_FacetWP extends FacetWP_Facet {
 		}
 
 		return $sources;
+	}
+
+	/**
+	 * Index MB relationships.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @param bool  $bypass Bypass default indexing.
+	 * @param array $params Extra helper data.
+	 *
+	 * @return array
+	 */
+	public function facetwp_indexer_post_facet( $bypass, $params ) {
+		if ( ! isset( $params['facet']['source'] ) || self::FACET_TYPE . '/' !== substr( $params['facet']['source'], 0, 17 ) ) {
+			return $bypass;
+		}
+
+		$this->indexer   = FWP()->indexer;
+		$relationship_id = substr( $params['facet']['source'], 17 );
+
+		$connected_objects = MB_Relationships_API::get_connected([
+			'id' => $relationship_id,
+			'from' => $params['defaults']['post_id'],
+		]);
+
+		// If no related objects, stop processing.
+		if ( empty( $connected_objects ) ) {
+			return true;
+		}
+
+		foreach ( $connected_objects as $connected_object ) {
+			$this->index_field_value( $connected_object, $params['defaults'] );
+		}
+
+		return $bypass;
+	}
+
+	/**
+	 * Manually index a relationship value.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @param WP_Post|WP_Term|WP_User $object Connected object.
+	 * @param array                   $params Extra helper data.
+	 *
+	 * @return void
+	 */
+	protected function index_field_value( $object, $params ) {
+		switch ( get_class( $object ) ) {
+			case WP_Term::class:
+				$params['facet_value']         = $object->term_id;
+				$params['facet_display_value'] = $object->name;
+				break;
+
+			case WP_User::class:
+				$params['facet_value']         = $object->ID;
+				$params['facet_display_value'] = $object->display_name;
+				break;
+
+			case WP_Post::class:
+			default:
+				$params['facet_value']         = $object->ID;
+				$params['facet_display_value'] = get_the_title( $object );
+				break;
+		}
+
+		/**
+		 * Filters the FacetWP data for a connected object.
+		 *
+		 * @since 1.12.0
+		 *
+		 * @param array $params FacetWP object params.
+		 * @param mixed $object Connected object.
+		 *
+		 * @return array
+		 */
+		$params = apply_filters( 'mb-relationships-facet-index-value', $params, $object );
+
+		$this->indexer->index_row( $params );
 	}
 }

--- a/inc/facetwp.php
+++ b/inc/facetwp.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * FacetWP integration
+ */
+class MB_Relationships_FacetWP extends FacetWP_Facet {
+
+	const FACET_TYPE = 'mb_relationships';
+
+	/**
+	 * Construct the class.
+	 *
+	 * @since 1.12.0
+	 */
+	public function __construct() {
+		$this->label = __( 'MB Relationships', 'mb-relationships' );
+		add_filter( 'facetwp_facet_sources', [ $this, 'facet_sources' ] );
+	}
+
+	/**
+	 * Add all registerd relationships as facet sources.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @param array $sources FacetWP sources.
+	 *
+	 * @return array
+	 */
+	public function facet_sources( $sources ) {
+		$choices = [];
+
+		$relationships = MB_Relationships_API::get_all_relationships();
+
+		foreach ( $relationships as $relationship ) {
+			$choices[ self::FACET_TYPE . '/' . $relationship->id ] = $relationship->id;
+		}
+
+		if ( ! empty( $choices ) ) {
+			$sources[ self::FACET_TYPE ] = array(
+				'label'   => __( 'MB Relationships', 'mb-relationships' ),
+				'choices' => $choices,
+				'weight'  => 7,
+			);
+		}
+
+		return $sources;
+	}
+}

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -59,6 +59,16 @@ class MBR_Loader {
 		$rest_api = new MB_Relationships_REST_API();
 		$rest_api->init();
 
+		add_filter(
+			'facetwp_facet_types',
+			function( $types ) {
+				require_once __DIR__ . '/facetwp.php';
+
+				$types[ MB_Relationships_FacetWP::FACET_TYPE ] = new MB_Relationships_FacetWP();
+				return $types;
+			}
+		);
+
 		// All registration code goes here.
 		do_action( 'mb_relationships_init' );
 	}


### PR DESCRIPTION
This adds FacetWP integration for all configured MB Relationships.

Here is a screenshot of the FacetWP settings showing all configured relationships available as data sources:

![Screenshot 2022-12-30 at 13 09 14](https://user-images.githubusercontent.com/784333/210104594-142b0338-6a73-4f96-a0b2-1536915c5262.png)

Would you like to add it in this plugin, or would you prefer to add it to https://github.com/wpmetabox/meta-box-facetwp-integrator instead?